### PR TITLE
Separate Banner CSS from JS. New primary channel banner location

### DIFF
--- a/src/components/WarningBanner.css
+++ b/src/components/WarningBanner.css
@@ -1,0 +1,123 @@
+.enshit-radar-warning {
+    position: relative ;
+    /* display: block; */
+    width: 100%;
+    border-color: 2px solid;
+    border-radius: 8px;
+    font-family: Roboto, Arial, sans-serif !important;;
+    font-size: 14px;
+    line-height: 1.4;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    margin-bottom: 16px;
+    z-index: 2;
+    animation: enshitRadarSlideIn 0.3s ease-out;
+    box-sizing: border-box;
+
+}
+
+.enshit-radar-warning * {
+    box-sizing: border-box;
+}
+
+.enshit-radar-warning-content {
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.enshit-radar-warning-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: bold;
+    font-size: 16px;
+}
+
+.enshit-radar-warning-close {
+    margin-left: auto;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 4px;
+    opacity: 0.7;
+    transition: opacity 0.2s, background-color 0.2s;
+}
+
+.enshit-radar-warning-body {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.enshit-radar-warning-description {
+    margin: 0;
+    font-size: 14px;
+    line-height: 1.5;
+}
+
+.enshit-radar-warning-details {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    font-size: 12px;
+    opacity: 0.8;
+}
+
+.enshit-radar-warning-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 4px;
+}
+
+.enshit-radar-warning-actions button {
+    padding: 6px 12px;
+    border: 1px solid; 
+    border-radius: 4px;
+    font-size: 12px;
+    cursor: pointer;
+    transition: all 0.2s;
+    background-color: transparent;
+}
+
+.enshit-radar-warning-actions button:hover {
+    background-color: rgba(0, 0, 0, 0.05);
+}
+
+.enshit-radar-warning-learn-more:hover {
+    opacity: 0.9;
+}
+
+.enshit-radar-warning-close {
+    opacity: 0.7;
+    background-color: transparent;
+}
+
+.enshit-radar-warning-close:hover {
+    opacity: 1;
+    background-color: rgba(0, 0, 0, 0.1);
+}
+
+@keyframes enshitRadarSlideIn {
+    from {
+        opacity: 0;
+        transform: translateY(-20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes enshitRadarSlideOut {
+    from {
+        opacity: 1;
+        transform: translateY(0);
+    }
+    to {
+        opacity: 0;
+        transform: translateY(-20px);
+    }
+}
+

--- a/src/components/WarningBanner.ts
+++ b/src/components/WarningBanner.ts
@@ -48,7 +48,7 @@ export class WarningBanner {
     `;
 
     // Apply styles
-    this.applyStyles(banner, config);
+    this.applyWarningStyle(banner, config);
     
     // Add event listeners
     this.addEventListeners(banner, channelRating);
@@ -58,137 +58,29 @@ export class WarningBanner {
   }
 
   /**
-   * Apply CSS styles to the banner
+   * Apply relevant styles to banner based off warning level
+   * @param banner 
+   * @param config 
    */
-  private applyStyles(banner: HTMLElement, config: WarningConfig): void {
-    // Main banner styles - full width by default (good for video pages)
-    Object.assign(banner.style, {
-      position: 'relative',
-      width: '100%',
-      backgroundColor: config.backgroundColor,
-      border: `2px solid ${config.borderColor}`,
-      borderRadius: '8px',
-      color: config.color,
-      fontFamily: 'Roboto, Arial, sans-serif',
-      fontSize: '14px',
-      lineHeight: '1.4',
-      boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1)',
-      marginBottom: '16px',
-      zIndex: '10000',
-      animation: 'enshitRadarSlideIn 0.3s ease-out',
-      boxSizing: 'border-box'
-    });
+  private applyWarningStyle(banner: HTMLElement, config: WarningConfig): void {
+    banner.style.backgroundColor = config.backgroundColor
+    banner.style.borderColor = config.borderColor
+    banner.style.color = config.color
 
-    // Content container
-    const content = banner.querySelector('.enshit-radar-warning-content') as HTMLElement;
-    Object.assign(content.style, {
-      padding: '16px',
-      display: 'flex',
-      flexDirection: 'column',
-      gap: '12px'
-    });
+    let closeBtn = banner.querySelector('.enshit-radar-warning-close') as HTMLElement;
+    closeBtn.style.color = config.color
 
-    // Header styles
-    const header = banner.querySelector('.enshit-radar-warning-header') as HTMLElement;
-    Object.assign(header.style, {
-      display: 'flex',
-      alignItems: 'center',
-      gap: '8px',
-      fontWeight: 'bold',
-      fontSize: '16px'
-    });
+    let allActionButtons = banner.querySelectorAll('.enshit-radar-warning-actions button')
+    allActionButtons.forEach((button) => {
+      let buttonElement = button as HTMLElement
+      buttonElement.style.borderColor = config.color
+      buttonElement.style.color = config.color
+    })
 
-    // Close button
-    const closeBtn = banner.querySelector('.enshit-radar-warning-close') as HTMLElement;
-    Object.assign(closeBtn.style, {
-      marginLeft: 'auto',
-      background: 'none',
-      border: 'none',
-      cursor: 'pointer',
-      padding: '4px',
-      borderRadius: '4px',
-      color: config.color,
-      opacity: '0.7',
-      transition: 'opacity 0.2s, background-color 0.2s'
-    });
-
-    // Body styles
-    const body = banner.querySelector('.enshit-radar-warning-body') as HTMLElement;
-    Object.assign(body.style, {
-      display: 'flex',
-      flexDirection: 'column',
-      gap: '8px'
-    });
-
-    // Description
-    const description = banner.querySelector('.enshit-radar-warning-description') as HTMLElement;
-    Object.assign(description.style, {
-      margin: '0',
-      fontSize: '14px',
-      lineHeight: '1.5'
-    });
-
-    // Details
-    const details = banner.querySelector('.enshit-radar-warning-details') as HTMLElement;
-    Object.assign(details.style, {
-      display: 'flex',
-      flexWrap: 'wrap',
-      gap: '12px',
-      fontSize: '12px',
-      opacity: '0.8'
-    });
-
-    // Actions
-    const actions = banner.querySelector('.enshit-radar-warning-actions') as HTMLElement;
-    Object.assign(actions.style, {
-      display: 'flex',
-      gap: '8px',
-      marginTop: '4px'
-    });
-
-    // Style action buttons
-    const buttons = actions.querySelectorAll('button');
-    buttons.forEach((button, index) => {
-      const isLearnMore = index === 0;
-      Object.assign(button.style, {
-        padding: '6px 12px',
-        border: `1px solid ${config.borderColor}`,
-        borderRadius: '4px',
-        fontSize: '12px',
-        cursor: 'pointer',
-        transition: 'all 0.2s',
-        backgroundColor: isLearnMore ? config.color : 'transparent',
-        color: isLearnMore ? config.backgroundColor : config.color
-      });
-    });
-
-    // Add hover effects with event listeners
-    closeBtn.addEventListener('mouseenter', () => {
-      closeBtn.style.opacity = '1';
-      closeBtn.style.backgroundColor = 'rgba(0, 0, 0, 0.1)';
-    });
-    closeBtn.addEventListener('mouseleave', () => {
-      closeBtn.style.opacity = '0.7';
-      closeBtn.style.backgroundColor = 'transparent';
-    });
-
-    buttons.forEach((button, index) => {
-      const isLearnMore = index === 0;
-      button.addEventListener('mouseenter', () => {
-        if (isLearnMore) {
-          button.style.opacity = '0.9';
-        } else {
-          button.style.backgroundColor = 'rgba(0, 0, 0, 0.05)';
-        }
-      });
-      button.addEventListener('mouseleave', () => {
-        if (isLearnMore) {
-          button.style.opacity = '1';
-        } else {
-          button.style.backgroundColor = 'transparent';
-        }
-      });
-    });
+    let learnMoreButton = banner.querySelector('.enshit-radar-warning-learn-more') as HTMLElement;
+    learnMoreButton.style.borderColor = config.borderColor
+    learnMoreButton.style.backgroundColor = config.color
+    learnMoreButton.style.color = config.backgroundColor
   }
 
   /**
@@ -223,12 +115,12 @@ export class WarningBanner {
     
     // For now, show an alert with more info
     const message = `
-Channel: ${channelRating.channelName}
-Risk Level: ${channelRating.level.toUpperCase()}
-Date Added: ${channelRating.dateAdded}
-${channelRating.source ? `Source: ${channelRating.source}` : ''}
+      Channel: ${channelRating.channelName}
+      Risk Level: ${channelRating.level.toUpperCase()}
+      Date Added: ${channelRating.dateAdded}
+      ${channelRating.source ? `Source: ${channelRating.source}` : ''}
 
-This information helps you make informed decisions about the content you consume.
+      This information helps you make informed decisions about the content you consume.
     `.trim();
     
     alert(message);
@@ -300,7 +192,16 @@ This information helps you make informed decisions about the content you consume
 
     let targetContainer: Element | null = null;
 
-        if (pageType === 'channel') {
+    if (pageType === 'channel') {
+      
+      // Primary Method of showing banner
+      let channelBannerElement = document.querySelector('#wrapper > #contentContainer')
+      if (channelBannerElement) {
+        channelBannerElement.appendChild(this.element);
+        this.setChannelPageStyles();
+        return true
+      }
+
       // More comprehensive selectors for both direct loads and SPA navigation
       const channelHeaderSelectors = [
         // New YouTube layout (direct load)
@@ -333,7 +234,7 @@ This information helps you make informed decisions about the content you consume
         // Insert the banner above the entire channel header
         channelHeaderElement.parentNode.insertBefore(this.element, channelHeaderElement);
         // Only adjust width for channel pages
-        this.adjustChannelBannerWidth();
+        this.setChannelPageStyles();
         return true;
       }
       
@@ -369,7 +270,7 @@ This information helps you make informed decisions about the content you consume
             }
           }
           
-          this.adjustChannelBannerWidth();
+          this.setChannelPageStyles();
           return true;
         }
       }
@@ -410,7 +311,7 @@ This information helps you make informed decisions about the content you consume
   /**
    * Adjust banner width on channel pages to be properly sized and centered
    */
-  private adjustChannelBannerWidth(): void {
+  private setChannelPageStyles(): void {
     if (!this.element) return;
     
     // Make the banner appropriately sized and centered
@@ -420,52 +321,8 @@ This information helps you make informed decisions about the content you consume
       marginLeft: 'auto',
       marginRight: 'auto',
       marginTop: '16px',
-      boxSizing: 'border-box'
+      boxSizing: 'border-box',
+      top: '-100%',
     });
   }
 }
-
-/**
- * Add CSS animations to the page
- */
-export function addWarningStyles(): void {
-  const styleId = 'enshit-radar-warning-styles';
-  
-  if (document.getElementById(styleId)) return;
-
-  const style = document.createElement('style');
-  style.id = styleId;
-  style.textContent = `
-    @keyframes enshitRadarSlideIn {
-      from {
-        opacity: 0;
-        transform: translateY(-20px);
-      }
-      to {
-        opacity: 1;
-        transform: translateY(0);
-      }
-    }
-    
-    @keyframes enshitRadarSlideOut {
-      from {
-        opacity: 1;
-        transform: translateY(0);
-      }
-      to {
-        opacity: 0;
-        transform: translateY(-20px);
-      }
-    }
-    
-    .enshit-radar-warning {
-      font-family: Roboto, Arial, sans-serif !important;
-    }
-    
-    .enshit-radar-warning * {
-      box-sizing: border-box;
-    }
-  `;
-  
-  document.head.appendChild(style);
-} 

--- a/src/content/youtube.ts
+++ b/src/content/youtube.ts
@@ -3,7 +3,7 @@ import { ExtensionMessage, MessageType, ExtensionSettings, YouTubePageInfo } fro
 import { sendToBackground, setupMessageListener } from '@/utils/messaging';
 import { detectYouTubePage, watchForYouTubeChanges } from '@/utils/youtube';
 import { channelDatabase } from '@/utils/channelDatabase';
-import { WarningBanner, addWarningStyles } from '@/components/WarningBanner';
+import { WarningBanner } from '@/components/WarningBanner';
 import { useSettingsStore } from '@/stores/settingsStore';
 
 // Prevent execution in sandboxed frames
@@ -26,9 +26,6 @@ async function initializeContentScript() {
     
     // Notify background that content script is loaded
     await sendToBackground(MessageType.CONTENT_LOADED, { url: window.location.href });
-    
-    // Set up styles for warnings
-    addWarningStyles();
     
     // Set up content-specific functionality
     setupPageObserver();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,6 +15,7 @@
         "*://m.youtube.com/*"
       ],
       "js": ["youtube.js"],
+      "css": ["bannerstyle.css"],
       "run_at": "document_end",
       "all_frames": false
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,8 @@ module.exports = (env, argv) => {
       background: './src/background/index.ts',
       youtube: './src/content/youtube.ts',
       popup: './src/popup/index.ts',
-      options: './src/options/index.ts'
+      options: './src/options/index.ts',
+      bannerstyle: './src/components/WarningBanner.css'
     },
     output: {
       path: path.resolve(__dirname, 'dist'),


### PR DESCRIPTION
### Change 1
**Problem**
The large warning banner on the channel page creates a gap above the featured video
<img width="1547" height="774" alt="chrome_2025-07-31-20-21-13" src="https://github.com/user-attachments/assets/bdaed7b9-2515-4613-bba6-c86e6e8c6afe" />
**Solution**
Change where the banner is added so there are no gaps. This is attempted first and if unsuccessful the previous attempts at adding the banner are used as fallback
<img width="1348" height="392" alt="chrome_2025-07-31-20-21-28" src="https://github.com/user-attachments/assets/de4c63cc-32c9-4a72-91b6-fd009c2a8b8d" />

### Change 2
**Problem**
The warning banner class file had lots of CSS embedded through JS, despite every element having its own CSS class 

**Solution**
Separate static CSS into its own file and leave only the dynamic styles in the class file. This makes the code easier to read and allows use of CSS as intended

